### PR TITLE
goci-1710-trait-sync-improvement trait sync rabbitmq messages

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <artifactId>gwasdepo-commons</artifactId>
 
-    <version>1.0.48-SNAPSHOT</version>
+    <version>1.0.49-SNAPSHOT</version>
 
     <packaging>jar</packaging>
 

--- a/src/main/java/uk/ac/ebi/spot/gwas/deposition/config/DiseaseTraitMQConfigProperties.java
+++ b/src/main/java/uk/ac/ebi/spot/gwas/deposition/config/DiseaseTraitMQConfigProperties.java
@@ -1,0 +1,20 @@
+package uk.ac.ebi.spot.gwas.deposition.config;
+
+import lombok.Data;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Data
+@Component
+public class DiseaseTraitMQConfigProperties {
+
+    @Value("${rabbitmq.diseasetrait.queue-name:#{NULL}}")
+    private String diseasetraitQueueName;
+
+    @Value("${rabbitmq.diseasetrait.exchange-name:#{NULL}}")
+    private String diseasetraitExchangeName;
+
+    @Value("${rabbitmq.diseasetrait.routing-key:#{NULL}}")
+    private String diseasetraitRoutingKey;
+
+}

--- a/src/main/java/uk/ac/ebi/spot/gwas/deposition/config/EFOTraitMQConfigProperties.java
+++ b/src/main/java/uk/ac/ebi/spot/gwas/deposition/config/EFOTraitMQConfigProperties.java
@@ -1,0 +1,20 @@
+package uk.ac.ebi.spot.gwas.deposition.config;
+
+import lombok.Data;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Data
+@Component
+public class EFOTraitMQConfigProperties {
+
+    @Value("${rabbitmq.efotrait.queue-name:#{NULL}}")
+    private String efoTraitQueueName;
+
+    @Value("${rabbitmq.efotrait.exchange-name:#{NULL}}")
+    private String efoTraitExchangeName;
+
+    @Value("${rabbitmq.efotrait.routing-key:#{NULL}}")
+    private String efoTraitRoutingKey;
+
+}

--- a/src/main/java/uk/ac/ebi/spot/gwas/deposition/dto/curation/DiseaseTraitRabbitMessage.java
+++ b/src/main/java/uk/ac/ebi/spot/gwas/deposition/dto/curation/DiseaseTraitRabbitMessage.java
@@ -1,0 +1,22 @@
+package uk.ac.ebi.spot.gwas.deposition.dto.curation;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class DiseaseTraitRabbitMessage {
+
+    @JsonProperty("trait")
+    private String trait;
+
+    @JsonProperty("mongoSeqId")
+    private String mongoSeqId;
+
+    @JsonProperty("operation")
+    private String operation;
+
+}

--- a/src/main/java/uk/ac/ebi/spot/gwas/deposition/dto/curation/EfoTraitRabbitMessage.java
+++ b/src/main/java/uk/ac/ebi/spot/gwas/deposition/dto/curation/EfoTraitRabbitMessage.java
@@ -1,0 +1,27 @@
+package uk.ac.ebi.spot.gwas.deposition.dto.curation;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class EfoTraitRabbitMessage {
+
+    @JsonProperty("trait")
+    private String trait;
+
+    @JsonProperty("uri")
+    private String uri;
+
+    @JsonProperty("shortForm")
+    private String shortForm;
+
+    @JsonProperty("mongoSeqId")
+    private String mongoSeqId;
+
+    @JsonProperty("operation")
+    private String operation;
+}


### PR DESCRIPTION
The PR is linked to the below tickets
https://github.com/EBISPOT/goci/issues/1710

The changes includes creating a message queue for handling messages for EFO Trait & Reported Trait changes . Existing rabbitmq queues are used , the consumer is running at codon cluster & listens to incoming messages & updates oracle at near real time basis, An email will be sent to curators in case the message consuming fails